### PR TITLE
Avoid fixed hostnames and schemes completely

### DIFF
--- a/assets/javascripts/spHelloBar/getRandomContent.js.es6
+++ b/assets/javascripts/spHelloBar/getRandomContent.js.es6
@@ -1,5 +1,5 @@
 export default function (cb) {
-  const host = (window.location.host == 'discourse.vm') ? 'http://www.blog.vm' : 'https://www.sitepoint.com';
+  const host = window.location.protocol + '//' + window.location.host;
 
   $.ajax({
     type: 'POST',


### PR DESCRIPTION
This never worked on staging, and hasn't worked in development for a long time.